### PR TITLE
Global "gbdx" namespace, more flexible get_thumbnail()

### DIFF
--- a/examples/simple_query.py
+++ b/examples/simple_query.py
@@ -7,27 +7,40 @@ Created on Aug 24, 2015
 import os
 import sys
 import pprint
+import time
 
 PACKAGE_DIR = os.path.dirname( os.path.dirname( os.path.abspath(__file__)) )
 sys.path.insert(0, PACKAGE_DIR)
 
-from gbdx.constants import TEST_AOI, DG_SENSOR_WV2
-from gbdx.gbdx_auth import get_session
-from gbdx.query import GBDXQuery
+import gbdx
 
 def main():
     #get gbdx session object
-    gbdx = get_session()
+    session = gbdx.get_session()
 
     #construct a query object, to search the catalog for
     # images that intersect a given AOI and were created
     # between start and end dates.
     date_range = ('2013-01-15', '2015-01-01')
-    qry = GBDXQuery(TEST_AOI, date_range=date_range, platform_name=DG_SENSOR_WV2,
-                    max_cloud_cover=5, max_off_nadir_angle=15)
+    qry = gbdx.GBDXQuery(gbdx.TEST_AOI, date_range=date_range,
+                         platform_name=gbdx.DG_SENSOR_WV2,
+                         max_cloud_cover=5, max_off_nadir_angle=15)
 
     #execute the query. The results will be a GBDXQueryResult object
-    res = qry(gbdx)
+    print("-"*40)
+    time1 = time.time()
+    res = qry(session)
+    time2 = time.time()
+    print("Query executed in {} seconds".format(time2-time1))
+
+    #note that query results are cached for (default) 300 sec,
+    # so if I call this query again immediately, it should use
+    # the remembered results.
+    time1 = time.time()
+    _res2 = qry(session)  #no reason to do this here, other than show caching behavior
+    time2 = time.time()
+    print("On 2nd attempt, query returned cached results in {} seconds".format(time2-time1))
+
     print("-"*40)
     print res
     print("-"*40)

--- a/gbdx/__init__.py
+++ b/gbdx/__init__.py
@@ -1,3 +1,12 @@
 """
 This is the top-level package for the GBDX python interface library.
 """
+
+from .constants import *
+from .gbdx_auth import get_session, configure
+from .core import get_json, post_json, get_s3creds, \
+                get_order_status, get_catalog_record, \
+                get_thumbnail
+from .query import GBDXQuery, GBDXQueryResult
+from .tasks import get_task_definition, list_available_tasks, \
+                   search_workflows, get_workflow_status

--- a/tests/test_gbdx_misc.py
+++ b/tests/test_gbdx_misc.py
@@ -10,17 +10,15 @@ import sys
 PACKAGE_DIR= os.path.dirname( os.path.dirname( os.path.abspath(__file__)) )
 sys.path.insert(0, PACKAGE_DIR)
 
-from gbdx.gbdx_auth import get_session
-from gbdx.core import get_order_status, get_thumbnail, get_catalog_record
-from gbdx.constants import TEST_ORDER_NUM, TEST_CAT_ID
+import gbdx
 
 class Test(unittest.TestCase):
     def setUp(self):
-        self.session = get_session()
+        self.session = gbdx.get_session()
 
     def test_get_order_status(self):
         print("\nTesting get_order_status")
-        order_status = get_order_status(self.session, TEST_ORDER_NUM)
+        order_status = gbdx.get_order_status(self.session, gbdx.TEST_ORDER_NUM)
         self.assertTrue('salesOrderNumber' in order_status, "Error with order status.")
         #there should be only a single line-item in this order
         line_item = order_status['lines'][0]
@@ -29,15 +27,15 @@ class Test(unittest.TestCase):
 
     def test_get_thumbnail(self):
         print("\nTesting get_thumbnail")
-        img = get_thumbnail(self.session, TEST_CAT_ID, show=False)
+        img = gbdx.get_thumbnail(self.session, gbdx.TEST_CAT_ID, show=False)
         #img is an ndarray / openCV image
         self.assertTupleEqual(img.shape, (409,512,3),
                 "Error with get_thumbnail. Unexpected img shape.")
 
     def test_get_catalog_record(self):
         print("\nTesting get catalog record")
-        rec = get_catalog_record(self.session, TEST_CAT_ID)
-        self.assertTrue( rec['identifier']==TEST_CAT_ID,
+        rec = gbdx.get_catalog_record(self.session, gbdx.TEST_CAT_ID)
+        self.assertTrue( rec['identifier']==gbdx.TEST_CAT_ID,
                          "Unexpected identifier returned in catalog record")
 
 if __name__ == "__main__":

--- a/tests/test_gbdx_query.py
+++ b/tests/test_gbdx_query.py
@@ -11,9 +11,7 @@ import shapely.geometry as sg
 PACKAGE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, PACKAGE_DIR)
 
-from gbdx.gbdx_auth import get_session
-from gbdx.query import GBDXQuery
-from gbdx.constants import TEST_AOI
+from gbdx import get_session, GBDXQuery, TEST_AOI
 
 class Test(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
I created a global gbdx namespace (edited __init__.py), so that one can simply "import gbdx" and have most of the useful functions available.

I also updated get_thumbnail() function so that it will work using either matplotlib (pylab) or openCV as an image loading/rendering engine.