### PR TITLE
Update test_tasks.py

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -26,7 +26,7 @@ class Test(unittest.TestCase):
         ret = gbdx.get_task_definition(self.sess, task_list[0])
         self.assertTrue("description" in ret.keys(), "Possibly invalid return for task definition")
 
-    def test_search_workflows(self):
+    def disable_search_workflows(self):
         print("\nTesting searching workflows")
         (workflow_ids, _) = gbdx.search_workflows(self.sess, state="all", owner=None,
                                                   lookback_h=24, details=False, verbose=False)


### PR DESCRIPTION
The test for searching workflows (test_search_workflows) should either start a workflow, so the state is known, or check for a successful return of workflow_ids. If there are 1 or more returned then do conduct the rest of the test.

Or the test should be disabled. This is the change I am proposing for now.