### PR TITLE
Simple wrapper for placing an order, new ability to filter a query result.

### DIFF
--- a/gbdx/__init__.py
+++ b/gbdx/__init__.py
@@ -6,7 +6,7 @@ from .constants import *
 from gbdx_auth.gbdx_auth import get_session
 from .core import get_json, post_json, get_s3creds, \
                 get_order_status, get_catalog_record, \
-                get_thumbnail
+                get_thumbnail, order_images
 from .query import GBDXQuery, GBDXQueryResult
 from .tasks import get_task_definition, list_available_tasks, \
                    search_workflows, get_workflow_status, \

--- a/gbdx/core.py
+++ b/gbdx/core.py
@@ -7,6 +7,7 @@ are wrappers to various GBDX RESTful API calls.
 """
 import numpy as np
 from io import BytesIO
+import json
 
 #Fancy importing to allow the user to use
 # either openCV or matplotlib for image rendering
@@ -39,7 +40,7 @@ def get_json(session, url):
 def post_json(session, url, payload):
     """
     Wrapper for session.post() when you want to get
-    the results as json. Handles the boilder plate
+    the results as json. Handles the boiler plate
     code for checking the result status and converting
     the result to json.
     """
@@ -54,6 +55,19 @@ def get_s3creds(session, duration=3600):
     s3_url = "s3://{bucket}/{prefix}".format(**s3_data)
     return (s3_url, s3_data)
 
+def order_images(session, cat_id_list):
+    """
+    Places an order for the list of catalog ids
+    @return: python dictionary containing information including
+    the salesOrderNumber (soli)
+    @note: Use get_order_status function to check on 
+    the progress of the order
+    """
+    url = "/".join([GBDX_BASE_URL,'orders','v1'])
+    payload = json.dumps(cat_id_list)
+    rc = post_json(session, url, payload)
+    return rc
+    
 def get_order_status(session, soli):
     """
     Retrieves the status information for a specified imagery order.

--- a/gbdx/query.py
+++ b/gbdx/query.py
@@ -33,6 +33,11 @@ class GBDXQuery(object):
         Constructor
         @param AOI: A shapely polygon object in WGS84 LON/LAT coordinates, from which
         a bounding box will be computed, or an input list/tuple as (lon0, lat0, lon1, lat1)
+        @note: The AOI will filter based on intersection. So if any part of the image intersects
+        the bounding box of the AOI, the image will be included in the results. To force a
+        "contains" logic, you should query, but then filter the results to further reduce
+        the set to only those which fully contain the AOI. See get_ids_containing_poly() in
+        the GBDXQueryResult object.
         @param date_range: A tuple (start_date, end_date), where the dates are specified
         as zero-padded YYYY-MM-DD strings. You may specify None as well. For example,
         to filter based on a start date you can set date_range=(2010-01-01, None).
@@ -213,6 +218,15 @@ class GBDXQueryResult(object):
         """
         f = self.get_property_from_id(ID, 'footprintWkt')
         return swkt.loads(f)
+    
+    def get_ids_containing_poly(self, poly):
+        """
+        Checks the footprint shape of each of the images in this result set,
+        and returns only those where the footprint fully contains the input
+        shapely polygon.
+        """
+        filtered = [ cid for cid in self.list_IDs() if self.get_footprint_from_id(cid).contains(poly) ]
+        return filtered
 
 def get_test_query_results():
     """


### PR DESCRIPTION
I added a simple wrapper around the REST api for placing an order. This is okay, and obviously needs to be in this codebase, but it could be better. For example, for each catid in an order, check to make sure it isn't already available first. Also, I found that if I try to place an order with too many catids at once, I get a timeout error. So we should either guard against that, or automatically chunk a large list into smaller order units.

I also added a method for the GBDXQueryResult to allow the user to quickly filter the return set to find only those catids which fully contain a polygon. Current GBDX logic with poly/AOI filtering is intersection logic. This is useful, for example, especially with ODP where we may be looking for airplanes on an airfield, we don't want a strip with only half the airfield.